### PR TITLE
Update bootstrap download and swig versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ static_setup:
 	git clone git://github.com/shutterstock/rickshaw.git deps/rickshaw
 	cd deps/rickshaw && git checkout $(RICKSHAW_VERSION) && make build
 	# get swig
-	curl -s http://paularmstrong.github.com/swig/js/swig.pack.min.js > deps/swig.min.js
+	curl -s http://paularmstrong.github.io/swig/js/swig.min.js > deps/swig.min.js
 	# build css
 	cat deps/rickshaw/rickshaw.min.css > deps/vendor.css
 	echo >> deps/vendor.css

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "redis": ">= 0.6.7",
     "setting": ">= 0.1.0",
     "socket.io": ">= 0.9.2",
-    "swig": "~> 0.13.4",
+    "swig": ">= 0.13.4",
     "uglify-js": ">= 2.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Update bootstrap URL now 3.0.0 has been released to 2.3.2 still works. Also change version call for swig as latest 1.0.0-pre doesn't seem to work
