### PR TITLE
properly define connect dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "setting": ">= 0.1.0",
     "socket.io": ">= 0.9.2",
     "swig": "1.3.0",
-    "uglify-js": ">= 2.2.5"
+    "uglify-js": ">= 2.2.5",
+    "connect": ">= 2.8; < 2.14"
   },
   "devDependencies": {
     "nodeunit": ">= 0.6.4"


### PR DESCRIPTION
it was not defined previously. Needs to be < 2.14 since 2.14 has a
failure around connect.HTTPServer and the Express framework that's being
used.

this will now build out of the box from a virgin 0.10.x nodejs install.
